### PR TITLE
fix: Pre-build all articles to prevent Vercel 500s

### DIFF
--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -1,4 +1,5 @@
 import fs from "fs";
+import path from "path";
 import { GetStaticPropsContext, InferGetStaticPropsType } from "next";
 import { serialize } from "next-mdx-remote/serialize";
 import { MDXRemote } from "next-mdx-remote";
@@ -22,7 +23,18 @@ export default function PostPage({
   );
 }
 export async function getStaticPaths() {
-  return { paths: [], fallback: "blocking" };
+  const articlesDirectory = path.join(process.cwd(), "articles");
+  const filenames = fs.readdirSync(articlesDirectory);
+
+  const paths = filenames
+    .filter((filename) => filename.endsWith(".mdx"))
+    .map((filename) => ({
+      params: {
+        slug: filename.replace(/\.mdx$/, ""),
+      },
+    }));
+
+  return { paths, fallback: false };
 }
 
 export async function getStaticProps(


### PR DESCRIPTION
This change modifies `getStaticPaths` in `pages/[slug].tsx` to read all .mdx files from the `articles` directory at build time. It generates paths for all articles and sets `fallback: false`.

This ensures that all article pages are pre-rendered during the build process, which should resolve the 500 errors you encountered on Vercel preview deployments for case study pages that were previously not being built upfront and were failing due to file system access issues in the serverless environment.